### PR TITLE
Always check that upload JSON can be parse, poll longer

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -192,8 +192,14 @@ class UserBehavior(TaskSet):
             with self.client.get(url, allow_redirects=False,
                                  name='/en-US/developers/upload/:uuid/json',
                                  catch_response=True) as response:
-                if response.status_code == 200:
+                try:
                     data = response.json()
+                except ValueError:
+                    return response.failure(
+                        'Failed to parse JSON when polling. '
+                        'Status: {} content: {}'.format(
+                            response.status_code, response.content))
+                if response.status_code == 200:
                     if data['error']:
                         return response.failure('Unexpected error: {}'.format(
                             data['error']))


### PR DESCRIPTION
I unfortunately haven't tested this because my docker won't start ([this](https://gist.githubusercontent.com/mstriemer/b92b4c7c4b68adaf227f/raw/d017098071367b6b300e6825dcca38aa09dfbbfa/-) is what I see).

We didn't see any JSON errors on the last run but hopefully we do in the future and this finds them. I also doubled the amount of time we'll poll for, maybe `200` was okay though?
